### PR TITLE
Application-Modules: Removing Python 2 executables during %install

### DIFF
--- a/application-modules.rst
+++ b/application-modules.rst
@@ -46,12 +46,20 @@ As we will be including the executable (application) only in the Python 3 subpac
 
 First, in the same manner as in the preceding `%build`_ section, it is advisable to upgrade the current Python 2 install command to use the new ``%py2_install`` macro, however, if that doesn't work for you, you can stick with the current install command, just make sure it's invoked by the ``%{__python2}`` macro.
 
-After that, add the corresponding Python 3 install command, which will be either be the custom command prefixed by ``%{__python3}`` or the new ``%py3_install`` macro.
+After the Python 2 install macro is run, it is likely going to install the Python 2 version of the application. As we want to package only the Python 3 version of the application, we have to remove the Python 2 executable so that the Python 3 version can take its place afterwards.
 
 .. code-block:: spec
 
     %install
     %py2_install
+    rm %{buildroot}%{_bindir}/sample-exec
+
+The ``%{buildroot}`` macro points to where the build root is being assembled, and ``%{_bindir}`` is a handy macro that substitutes to ``/usr/bin/``. If the package installs multiple executables, be sure to remove each and every one of them.
+
+After that, add the corresponding Python 3 install command, which will be either the custom command prefixed by ``%{__python3}`` or the new ``%py3_install`` macro.
+
+.. code-block:: spec
+
     %py3_install
 
 .. include:: /snippets/install_non-python-script.inc

--- a/application-modules.rst
+++ b/application-modules.rst
@@ -40,7 +40,22 @@ As we will be including the executable (application) only in the Python 3 subpac
 
 .. include:: subsections/h3-build.inc
 
-.. include:: subsections/h3-install.inc
+
+%install
+^^^^^^^^
+
+First, in the same manner as in the preceding `%build`_ section, it is advisable to upgrade the current Python 2 install command to use the new ``%py2_install`` macro, however, if that doesn't work for you, you can stick with the current install command, just make sure it's invoked by the ``%{__python2}`` macro.
+
+After that, add the corresponding Python 3 install command, which will be either be the custom command prefixed by ``%{__python3}`` or the new ``%py3_install`` macro.
+
+.. code-block:: spec
+
+    %install
+    %py2_install
+    %py3_install
+
+.. include:: /snippets/install_non-python-script.inc
+
 
 .. include:: subsections/h3-check.inc
 

--- a/application-modules.rst
+++ b/application-modules.rst
@@ -54,6 +54,12 @@ After the Python 2 install macro is run, it is likely going to install the Pytho
     %py2_install
     rm %{buildroot}%{_bindir}/*
 
+.. note::
+
+   It is not enough just to run the Python install macros in the right order (first 2 then 3), because the Python installation mechanism (distutils) can sometimes refuse to override files in ``/usr/bin``. Even if it works on your machine™, be aware that this might happen on other build systems like Koji or Copr. The issue is also `very hard to preduce`_. That is why it is highly recommended to delete the executables between installs as shown here.
+
+.. _`very hard to preduce`: https://lists.fedoraproject.org/archives/list/python-devel@lists.fedoraproject.org/thread/P54Z3BZKZOZDWWCZN56CUAGIQPEQCYPP/
+
 After that, add the corresponding Python 3 install command, which will be either the custom command prefixed by ``%{__python3}`` or the new ``%py3_install`` macro.
 
 .. code-block:: spec

--- a/application-modules.rst
+++ b/application-modules.rst
@@ -46,15 +46,13 @@ As we will be including the executable (application) only in the Python 3 subpac
 
 First, in the same manner as in the preceding `%build`_ section, it is advisable to upgrade the current Python 2 install command to use the new ``%py2_install`` macro, however, if that doesn't work for you, you can stick with the current install command, just make sure it's invoked by the ``%{__python2}`` macro.
 
-After the Python 2 install macro is run, it is likely going to install the Python 2 version of the application. As we want to package only the Python 3 version of the application, we have to remove the Python 2 executable so that the Python 3 version can take its place afterwards.
+After the Python 2 install macro is run, it is likely going to install the Python 2 version of the application. As we want to package only the Python 3 version of the application, we have to remove the Python 2 executable(s) that were installed into ``/usr/bin/`` so that the Python 3 version(s) can take their place afterwards.
 
 .. code-block:: spec
 
     %install
     %py2_install
-    rm %{buildroot}%{_bindir}/sample-exec
-
-The ``%{buildroot}`` macro points to where the build root is being assembled, and ``%{_bindir}`` is a handy macro that substitutes to ``/usr/bin/``. If the package installs multiple executables, be sure to remove each and every one of them.
+    rm %{buildroot}%{_bindir}/*
 
 After that, add the corresponding Python 3 install command, which will be either the custom command prefixed by ``%{__python3}`` or the new ``%py3_install`` macro.
 

--- a/specs/application-module.spec
+++ b/specs/application-module.spec
@@ -52,10 +52,9 @@ A Python tool which provides a convenient example.
 
 # The Python 2 installation process will likely try to install its own version
 # of the application. As we only want to package the Python 3 version of the
-# application, we delete the Python 2 executable so that the Python 3 version
-# can take it's place afterwards. In case of multiple executables being
-# installed, remove each and every one.
-rm %{buildroot}%{_bindir}/sample-exec
+# application, we delete the Python 2 executable(s) so that the Python 3
+# version(s) can take their place afterwards.
+rm %{buildroot}%{_bindir}/*
 
 %py3_install
 

--- a/specs/application-module.spec
+++ b/specs/application-module.spec
@@ -48,33 +48,16 @@ A Python tool which provides a convenient example.
 
 
 %install
-# Here we have to think about the order, because the scripts in /usr/bin are
-# overwritten with every setup.py install.
-# If the script in /usr/bin provides the same functionality regardless
-# of the Python version, we only provide Python 3 version and we need to run
-# the py3_install after py2_install.
-
-# If we need to include the executable both for Python 2 and 3--for example
-# because it interacts with code from the user--then the default executable
-# should be the one for Python 2.
-# We are going to assume that case here, because it is a bit more complex.
-
-%py3_install
-
-# Now /usr/bin/sample-exec is Python 3, so we move it away
-mv %{buildroot}%{_bindir}/sample-exec %{buildroot}%{_bindir}/sample-exec-%{python3_version}
-
 %py2_install
 
-# Now /usr/bin/sample-exec is Python 2, and we move it away anyway
-mv %{buildroot}%{_bindir}/sample-exec %{buildroot}%{_bindir}/sample-exec-%{python2_version}
+# The Python 2 installation process will likely try to install its own version
+# of the application. As we only want to package the Python 3 version of the
+# application, we delete the Python 2 executable so that the Python 3 version
+# can take it's place afterwards. In case of multiple executables being
+# installed, remove each and every one.
+rm %{buildroot}%{_bindir}/sample-exec
 
-# The guidelines also specify we must provide symlinks with a '-X' suffix.
-ln -s ./sample-exec-%{python2_version} %{buildroot}%{_bindir}/sample-exec-2
-ln -s ./sample-exec-%{python3_version} %{buildroot}%{_bindir}/sample-exec-3
-
-# Finally, we provide /usr/bin/sample-exec as a link to /usr/bin/sample-exec-2
-ln -s ./sample-exec-2 %{buildroot}%{_bindir}/sample-exec
+%py3_install
 
 
 %check

--- a/subsections/h3-install.inc
+++ b/subsections/h3-install.inc
@@ -3,7 +3,7 @@
 
 First, in the same manner as in the preceding `%build`_ section, it is advisable to upgrade the current Python 2 install command to use the new ``%py2_install`` macro, however, if that doesn't work for you, you can stick with the current install command, just make sure it's invoked by the ``%{__python2}`` macro.
 
-After that, add the corresponding Python 3 install command, which will be either be the custom command prefixed by ``%{__python3}`` or the new ``%py3_install`` macro.
+After that, add the corresponding Python 3 install command, which will be either the custom command prefixed by ``%{__python3}`` or the new ``%py3_install`` macro.
 
 .. code-block:: spec
 


### PR DESCRIPTION
This is in reference to the discussion by John Dennis on python-devel Fedora mailing list.

Content changes are only in the second commit, first commit is refactoring.

Does it look a-ok, @encukou, @hroncok ?

Here it is built: http://python-rpm-porting.readthedocs.io/en/pr-install/
