### PR TITLE
PyPI URL in specs changed to the new form

### DIFF
--- a/specs/application-module.spec
+++ b/specs/application-module.spec
@@ -8,7 +8,7 @@ Summary:        %{sum}
 
 License:        MIT
 URL:            http://pypi.python.org/pypi/%{srcname}
-Source0:        http://pypi.python.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python2-devel

--- a/specs/application.spec
+++ b/specs/application.spec
@@ -7,7 +7,7 @@ Summary:        An example Python application
 
 License:        MIT
 URL:            http://pypi.python.org/pypi/%{srcname}
-Source0:        http://pypi.python.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python3-devel

--- a/specs/application.spec.orig
+++ b/specs/application.spec.orig
@@ -7,7 +7,7 @@ Summary:        An example Python application
 
 License:        MIT
 URL:            http://pypi.python.org/pypi/%{srcname}
-Source0:        http://pypi.python.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python-devel

--- a/specs/module.spec
+++ b/specs/module.spec
@@ -8,7 +8,7 @@ Summary:        %{sum}
 
 License:        MIT
 URL:            http://pypi.python.org/pypi/%{srcname}
-Source0:        http://pypi.python.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python2-devel

--- a/specs/module.spec.orig
+++ b/specs/module.spec.orig
@@ -7,7 +7,7 @@ Summary:        An example Python module
 
 License:        MIT
 URL:            http://pypi.python.org/pypi/%{srcname}
-Source0:        http://pypi.python.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python-devel

--- a/specs/tool.spec
+++ b/specs/tool.spec
@@ -8,7 +8,7 @@ Summary:        %{sum}
 
 License:        MIT
 URL:            http://pypi.python.org/pypi/%{srcname}
-Source0:        http://pypi.python.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python2-devel

--- a/specs/tool.spec.orig
+++ b/specs/tool.spec.orig
@@ -7,7 +7,7 @@ Summary:        An example Python tool
 
 License:        MIT
 URL:            http://pypi.python.org/pypi/%{srcname}
-Source0:        http://pypi.python.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python-devel


### PR DESCRIPTION
PyPI does not use the the old readable URL form for sources anymore. This should not be included in example specfiles.
