### PR TITLE
Transfer to the new naming scheme

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,8 @@
 Copyright
 
-(c) 2016 Red Hat, Inc.
+(c) 2016-2017 Red Hat, Inc.
 (c) 2016 Tomas Orsava
+(c) 2017 Iryna Shcherbina
 (c) 2016 Miro Hroncok
 (c) 2016 Petr Viktorin
 (c) 2016 Other contributors [0]

--- a/index.rst
+++ b/index.rst
@@ -86,8 +86,8 @@ If your package is being imported by third-party projects, but does not have any
 
 *See:* :doc:`tools`
 
-Make sure to follow the new naming scheme
------------------------------------------
+Are you following the new Python package naming scheme?
+-------------------------------------------------------
 
 .. include:: snippets/naming_scheme.inc
 

--- a/index.rst
+++ b/index.rst
@@ -6,6 +6,7 @@
    modules
    application-modules
    tools
+   naming-scheme
 
 
 =======================================
@@ -84,3 +85,10 @@ If your package is being imported by third-party projects, but does not have any
 .. include:: snippets/desc_tools.inc
 
 *See:* :doc:`tools`
+
+Make sure to follow the new naming scheme
+-----------------------------------------
+
+.. include:: snippets/naming_scheme.inc
+
+*See:* :doc:`naming-scheme`

--- a/naming-scheme.rst
+++ b/naming-scheme.rst
@@ -4,7 +4,7 @@ New Python package naming scheme
 .. include:: snippets/naming_scheme.inc
 
 .. note::
-	This section is related to the renaming of Python **binary RPM** packages to avoid using the ``python-`` prefix without a version. Changing the package/SRPM name is not required.
+	This section is related to the renaming of Python **binary RPM** packages to avoid using the ``python-`` prefix without a version. Changing the main package/SRPM name is not required.
 
 Why is this important?
 ----------------------
@@ -29,7 +29,7 @@ See the following naming schemes which violate the current naming guidelines:
 
    *  -  SRPM
       -  Binary RPMs built
-      -  Violaion
+      -  Violation
    *  -  python-<srcname>
       -  | python-<srcname>
       -  unversioned `python-` prefix in the binary package
@@ -56,7 +56,7 @@ The change should look like this:
 
 .. literalinclude:: specs/module.spec
 	:diff: specs/module.spec.orig
-	:lines: 15-19,21-33
+	:lines: 15-19,21-32,43
 
 .. _%python_provide: modules.html#python-provide
 

--- a/naming-scheme.rst
+++ b/naming-scheme.rst
@@ -1,5 +1,5 @@
-Following the new naming scheme
-===============================
+New Python package naming scheme
+================================
 
 .. include:: snippets/naming_scheme.inc
 
@@ -16,7 +16,7 @@ Using the outdated naming scheme in your subpackage names or run-time/build-time
 What needs to be changed?
 -------------------------
 
-Check the names of binary packages you are building from your SRPM, and if you use one of the following naming schemes, you'll find instructions on how to fix it in the `section below <required_changes_>`_.
+Check the names of binary RPM packages you are building from your SRPM, and if you use one of the following naming schemes, you'll find instructions on how to fix it in the `section below <required_changes_>`_.
 
 Common naming scheme violations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/naming-scheme.rst
+++ b/naming-scheme.rst
@@ -4,19 +4,19 @@ Following the new naming scheme
 .. include:: snippets/naming_scheme.inc
 
 .. note::
-	This is mostly related to renaming Python **binary** packages to avoid using ``python-`` prefix without a version and does not require changing the SRPM name.
+	This section is related to the renaming of Python **binary RPM** packages to avoid using the ``python-`` prefix without a version. Changing the package/SRPM name is not required.
 
-Why is this so important?
--------------------------
+Why is this important?
+----------------------
 
-When the time comes and ``python`` means Python 3 in Fedora, installing a ``python-<srcname>`` package will imply a Python 3 version of this package. This is planned for 2020, when upstream support for Python 2 ends. To achieve this all Python binary packages have to follow the new naming scheme and use ``%python_provide`` macro, devised to make the switch easier. However, currently we are far away from achieving this goal.
+When the time comes and ``python`` means Python 3 in Fedora, installing a ``python-<srcname>`` package will imply a Python 3 version of this package. This is planned for 2020, when upstream support for Python 2 ends. To achieve this, all Python binary RPM packages have to follow the new naming scheme and use the ``%python_provide`` macro, devised to make the switch easier. However, we are still far away from achieving this goal.
 
-Using outdated naming scheme in your subpackage names or runtime/builtime requirements might cause a range of issues when the switch happens.
+Using the outdated naming scheme in your subpackage names or run-time/build-time requirements might cause a range of issues when the switch happens.
 
 What needs to be changed?
 -------------------------
 
-Check the names of binary packages you are building from your SRPM, and if you use one of the following naming schemes, fix it with the instructions provided in `Required changes`_.
+Check the names of binary packages you are building from your SRPM, and if you use one of the following naming schemes, you'll find instructions on how to fix it in the `section below <required_changes_>`_.
 
 Common naming scheme violations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ See the following naming schemes which violate the current naming guidelines:
    :stub-columns: 1
 
    *  -  SRPM
-      -  RPMs built
+      -  Binary RPMs built
       -  Violaion
    *  -  python-<srcname>
       -  | python-<srcname>
@@ -42,24 +42,26 @@ See the following naming schemes which violate the current naming guidelines:
          | python3-<srcname>
       -  missing `python2-` prefix in the binary package
 
+.. _required_changes:
+
 Required changes
 ^^^^^^^^^^^^^^^^
 
-Add ``%package`` section for the Python 2 subpackage
-""""""""""""""""""""""""""""""""""""""""""""""""""""
+Add a ``%package`` section for the Python 2 subpackage
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-To rename the binary package to ``python2-<srcname>``, you should build it as a subpackage with an appropriate name. Make sure to move all related runtime requirements and use `%python_provide`_ macro, which will provide both ``python-<srcname>`` and ``python2-<srcname>`` until the switch to Python 3 happens.
+To rename the binary RPM package to ``python2-<srcname>``, you should build it as a subpackage with an appropriate name. Make sure to move all related runtime requirements from the main package to the new subpackage and use the `%python_provide`_ macro, which will provide both ``python-<srcname>`` and ``python2-<srcname>`` until the switch to Python 3 happens.
 
-The change you are about to do should look like this:
+The change should look like this:
 
 .. literalinclude:: specs/module.spec
 	:diff: specs/module.spec.orig
-	:lines: 15-19,21-34
+	:lines: 15-19,21-33
 
 .. _%python_provide: modules.html#python-provide
-	
-Use ``%python_provide`` macro in the Python 3 subpackage
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Use the ``%python_provide`` macro in the Python 3 subpackage
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Check your Python 3 subpackage (if you build any), and make sure you are using the `%python_provide`_ macro to handle provides:
 
@@ -68,13 +70,13 @@ Check your Python 3 subpackage (if you build any), and make sure you are using t
 	:emphasize-lines: 5
 	:lines: 30-37
 
-Rename ``%files`` section
-"""""""""""""""""""""""""
+Rename the ``%files`` section
+"""""""""""""""""""""""""""""
 
-Give a name with a versioned prefix to the current ``%files`` section, and make sure to use new versioned macros ``%{python2_sitelib}``, ``%{python2_sitearch}``, ``%{python2_version}``:
+To assign the ``%files`` section to the Python 2 subpackage, add the subpackage name with the versioned prefix after the ``%files`` macro. Make sure to use the new versioned macros ``%{python2_sitelib}``, ``%{python2_sitearch}``, and ``%{python2_version}`` as well:
 
 .. literalinclude:: specs/module.spec
 	:diff: specs/module.spec.orig
 	:lines: 67-68,70-74
 
-At this point you should be done. Just bump the release tag and add a changelog that you've updated the package to use the new naming scheme.
+At this point you should be done. Don't forget to bump the release tag and add a changelog entry indicating you've updated the package to use the new naming scheme.

--- a/naming-scheme.rst
+++ b/naming-scheme.rst
@@ -69,7 +69,7 @@ Note, that in case of the last naming scheme example in the `table above <common
    Provides:   %{srcname} = %{version}-%{release}
    Obsoletes:  %{srcname} < current_version-current_release
 
-In the Obsoletes tag, ``current_version`` and ``current_release`` are the hardcoded version and release that were current when you did the change.
+In the Obsoletes tag, ``current_version`` and ``current_release`` are the first version and release when the new naming scheme was used.
 
 .. _%python_provide: modules.html#python-provide
 

--- a/naming-scheme.rst
+++ b/naming-scheme.rst
@@ -4,7 +4,7 @@ New Python package naming scheme
 .. include:: snippets/naming_scheme.inc
 
 .. note::
-	This section is related to the renaming of Python **binary RPM** packages to avoid using the ``python-`` prefix without a version. Changing the main package/SRPM name is not required.
+   This section is related to the renaming of Python **binary RPM** packages to avoid using the ``python-`` prefix without a version. Changing the main package/SRPM name is not required.
 
 Why is this important?
 ----------------------
@@ -17,6 +17,8 @@ What needs to be changed?
 -------------------------
 
 Check the names of binary RPM packages you are building from your SRPM, and if you use one of the following naming schemes, you'll find instructions on how to fix it in the `section below <required_changes_>`_.
+
+.. _common_naming_scheme_violations:
 
 Common naming scheme violations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,8 +57,18 @@ To rename the binary RPM package to ``python2-<srcname>``, you should build it a
 The change should look like this:
 
 .. literalinclude:: specs/module.spec
-	:diff: specs/module.spec.orig
-	:lines: 15-19,21-32,43
+   :diff: specs/module.spec.orig
+   :lines: 15-19,21-32,43
+
+Note, that in case of the last naming scheme example in the `table above <common_naming_scheme_violations_>`_, when you rename the binary RPM from ``<srcname>`` to ``python2-<srcname>``, the `%python_provide`_ macro will not provide the old name ``<srcname>``. To keep the upgrade path clean you will have to provide it and obsolete the old verision manually. You may place the tags right after the `%python_provide`_ macro:
+
+.. code-block:: spec
+   :emphasize-lines: 2,3
+
+   %{?python_provide:%python_provide python2-%{srcname}}
+   Provides:   <srcname> = %{version}-%{release}
+   Obsoletes:  <srcname> <= %{version}-%{release}
+
 
 .. _%python_provide: modules.html#python-provide
 
@@ -66,9 +78,9 @@ Use the ``%python_provide`` macro in the Python 3 subpackage
 Check your Python 3 subpackage (if you build any), and make sure you are using the `%python_provide`_ macro to handle provides:
 
 .. literalinclude:: specs/module.spec
-	:language: spec
-	:emphasize-lines: 5
-	:lines: 30-37
+   :language: spec
+   :emphasize-lines: 5
+   :lines: 30-37
 
 Rename the ``%files`` section
 """""""""""""""""""""""""""""
@@ -76,7 +88,7 @@ Rename the ``%files`` section
 To assign the ``%files`` section to the Python 2 subpackage, add the subpackage name with the versioned prefix after the ``%files`` macro. Make sure to use the new versioned macros ``%{python2_sitelib}``, ``%{python2_sitearch}``, and ``%{python2_version}`` as well:
 
 .. literalinclude:: specs/module.spec
-	:diff: specs/module.spec.orig
-	:lines: 67-68,70-74
+   :diff: specs/module.spec.orig
+   :lines: 67-68,70-74
 
 At this point you should be done. Don't forget to bump the release tag and add a changelog entry indicating you've updated the package to use the new naming scheme.

--- a/naming-scheme.rst
+++ b/naming-scheme.rst
@@ -66,9 +66,10 @@ Note, that in case of the last naming scheme example in the `table above <common
    :emphasize-lines: 2,3
 
    %{?python_provide:%python_provide python2-%{srcname}}
-   Provides:   <srcname> = %{version}-%{release}
-   Obsoletes:  <srcname> <= %{version}-%{release}
+   Provides:   %{srcname} = %{version}-%{release}
+   Obsoletes:  %{srcname} < current_version-current_release
 
+In the Obsoletes tag, ``current_version`` and ``current_release`` are the hardcoded version and release that were current when you did the change.
 
 .. _%python_provide: modules.html#python-provide
 

--- a/naming-scheme.rst
+++ b/naming-scheme.rst
@@ -1,0 +1,80 @@
+Following the new naming scheme
+===============================
+
+.. include:: snippets/naming_scheme.inc
+
+.. note::
+	This is mostly related to renaming Python **binary** packages to avoid using ``python-`` prefix without a version and does not require changing the SRPM name.
+
+Why is this so important?
+-------------------------
+
+When the time comes and ``python`` means Python 3 in Fedora, installing a ``python-<srcname>`` package will imply a Python 3 version of this package. This is planned for 2020, when upstream support for Python 2 ends. To achieve this all Python binary packages have to follow the new naming scheme and use ``%python_provide`` macro, devised to make the switch easier. However, currently we are far away from achieving this goal.
+
+Using outdated naming scheme in your subpackage names or runtime/builtime requirements might cause a range of issues when the switch happens.
+
+What needs to be changed?
+-------------------------
+
+Check the names of binary packages you are building from your SRPM, and if you use one of the following naming schemes, fix it with the instructions provided in `Required changes`_.
+
+Common naming scheme violations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See the following naming schemes which violate the current naming guidelines:
+
+.. list-table:: 
+   :header-rows: 1
+   :stub-columns: 1
+
+   *  -  SRPM
+      -  RPMs built
+      -  Violaion
+   *  -  python-<srcname>
+      -  | python-<srcname>
+      -  unversioned `python-` prefix in the binary package
+   *  -  python-<srcname>
+      -  | python-<srcname>
+         | python3-<srcname>
+      -  unversioned `python-` prefix in the binary package
+   *  -  <srcname>
+      -  | <srcname>
+         | python3-<srcname>
+      -  missing `python2-` prefix in the binary package
+
+Required changes
+^^^^^^^^^^^^^^^^
+
+Add ``%package`` section for the Python 2 subpackage
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+To rename the binary package to ``python2-<srcname>``, you should build it as a subpackage with an appropriate name. Make sure to move all related runtime requirements and use `%python_provide`_ macro, which will provide both ``python-<srcname>`` and ``python2-<srcname>`` until the switch to Python 3 happens.
+
+The change you are about to do should look like this:
+
+.. literalinclude:: specs/module.spec
+	:diff: specs/module.spec.orig
+	:lines: 15-19,21-34
+
+.. _%python_provide: modules.html#python-provide
+	
+Use ``%python_provide`` macro in the Python 3 subpackage
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Check your Python 3 subpackage (if you build any), and make sure you are using the `%python_provide`_ macro to handle provides:
+
+.. literalinclude:: specs/module.spec
+	:language: spec
+	:emphasize-lines: 5
+	:lines: 30-37
+
+Rename ``%files`` section
+"""""""""""""""""""""""""
+
+Give a name with a versioned prefix to the current ``%files`` section, and make sure to use new versioned macros ``%{python2_sitelib}``, ``%{python2_sitearch}``, ``%{python2_version}``:
+
+.. literalinclude:: specs/module.spec
+	:diff: specs/module.spec.orig
+	:lines: 67-68,70-74
+
+At this point you should be done. Just bump the release tag and add a changelog that you've updated the package to use the new naming scheme.

--- a/snippets/naming_scheme.inc
+++ b/snippets/naming_scheme.inc
@@ -1,3 +1,3 @@
-If you have ported your package in accordance with the guidance in the above sections, then it most certainly complies with the `Python package naming guidelines`_. However, you might have done it before this guide came to life or even before the naming guidelines changed, which might mean that some name changes are required. This section is here to walk you through them.
+If you have ported your package according to the guidance in previous sections, then it most certainly complies with the `Python package naming guidelines`_. However, you might have done it before this guide came to life or even before the naming guidelines changed, which might mean that some name changes are required. This section is here to walk you through them.
 
 .. _Python package naming guidelines: https://fedoraproject.org/wiki/Packaging:Naming?rd=Packaging:NamingGuidelines#Python_source_package_naming

--- a/snippets/naming_scheme.inc
+++ b/snippets/naming_scheme.inc
@@ -1,0 +1,3 @@
+If you have ported your package in accordance with the guidance in the above sections, then it most certainly complies with the `Python package naming guidelines`_. However, you might have done it before this guide came to life or even before the naming guidelines changed, which might mean that some name changes are required. This section is here to walk you through them.
+
+.. _Python package naming guidelines: https://fedoraproject.org/wiki/Packaging:Naming?rd=Packaging:NamingGuidelines#Python_source_package_naming

--- a/specs/module.spec
+++ b/specs/module.spec
@@ -19,7 +19,7 @@ A Python module which provides a convenient example.
 
 %package -n python2-%{srcname}
 Summary:        %{summary}
-Requires:       python-some-module
+Requires:       python2-some-module
 Requires:       python2-other-module
 %{?python_provide:%python_provide python2-%{srcname}}
 

--- a/specs/module.spec.orig
+++ b/specs/module.spec.orig
@@ -11,8 +11,8 @@ Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{sr
 
 BuildArch:      noarch
 BuildRequires:  python-devel
-Requires: python-some-module
-Requires: python2-other-module
+Requires:       python-some-module
+Requires:       python2-other-module
 
 %description
 A Python module which provides a convenient example.


### PR DESCRIPTION
This is a first draft of the instructions for transferring to the new naming scheme.

The build should be available here: https://irushchyshyn.github.io/python-rpm-porting
Page: https://irushchyshyn.github.io/python-rpm-porting/naming-scheme.html